### PR TITLE
Refactor: avoid the extra array traversal for performance

### DIFF
--- a/string_calculator.rb
+++ b/string_calculator.rb
@@ -16,6 +16,7 @@
 #   7. The `add` method should ignore numbers greater than 1000
 ##################################################################################
 class StringCalculator
+  MAX_VALUE = 1000
   def add(string)
     # If the string is empty, return 0
     return 0 if string.empty?
@@ -24,9 +25,8 @@ class StringCalculator
     string = extract_custom_delimiters(string)
 
     numbers = numbers_array(string)
-    # numbers greater than 1000 should be ignored
-    numbers = numbers.reject { |number| number > 1000 }
-    numbers.sum
+    # sum in one pass, ignoring values > MAX_VALUE
+    numbers.sum { |n| n <= MAX_VALUE ? n : 0 }
   end
 
   private

--- a/string_calculator.rb
+++ b/string_calculator.rb
@@ -13,6 +13,7 @@
 #        at the beginning of the string after the `//` prefix
 #   5. The `add` method raising an exception if negative numbers present in the string
 #   6. The `add` method should also handle multiple negative numbers showing all negative numbers in exception message
+#   7. The `add` method should ignore numbers greater than 1000
 ##################################################################################
 class StringCalculator
   def add(string)
@@ -23,6 +24,8 @@ class StringCalculator
     string = extract_custom_delimiters(string)
 
     numbers = numbers_array(string)
+    # numbers greater than 1000 should be ignored
+    numbers = numbers.reject { |number| number > 1000 }
     numbers.sum
   end
 

--- a/test_string_calculator.rb
+++ b/test_string_calculator.rb
@@ -56,4 +56,10 @@ class TestStringCalculator < Minitest::Test
     error = assert_raises(Exception) { @calculator.add("//;\n2,-3\n\n \n -8\n 4; -2;") }
     assert_match(/negative numbers not allowed -3, -8, -2/, error.message)
   end
+
+  def test_ignore_numbers_greater_than_thousand
+    assert_equal 2, @calculator.add('1001,2')
+    assert_equal 1006, @calculator.add("//)1\n2,3\n)\n1000)")
+    assert_equal 8, @calculator.add("4\n\n3\n1001,\n1002,\n\n1003,\n1")
+  end
 end

--- a/test_string_calculator.rb
+++ b/test_string_calculator.rb
@@ -59,7 +59,7 @@ class TestStringCalculator < Minitest::Test
 
   def test_ignore_numbers_greater_than_thousand
     assert_equal 2, @calculator.add('1001,2')
-    assert_equal 1006, @calculator.add("//)1\n2,3\n)\n1000)")
+    assert_equal 1006, @calculator.add("//)\n1\n2,3\n)\n1000)")
     assert_equal 8, @calculator.add("4\n\n3\n1001,\n1002,\n\n1003,\n1")
   end
 end


### PR DESCRIPTION
Refactor: avoid the extra array traversal for performance

1. Avoid the extra array traversal and use sum's block for rejecting numbers greater than 1000